### PR TITLE
Stop using CFURLCreateStringByAddingPercentEscapes()

### DIFF
--- a/SquareRegisterSDK.podspec
+++ b/SquareRegisterSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'SquareRegisterSDK'
-  s.version      = '1.0.0'
+  s.version      = '1.0.1'
   s.summary      = 'SDK for clients using Register API on iOS'
   s.homepage     = 'https://github.com/square/SquareRegisterSDK-iOS/'
   s.license      = { :type => 'Apache License, Version 2.0', :text => "© #{ Date.today.year } Square, Inc." }

--- a/SquareRegisterSDK/SCCAPIRequest.m
+++ b/SquareRegisterSDK/SCCAPIRequest.m
@@ -260,13 +260,12 @@ static NSString *__nullable APIClientID = nil;
         return nil;
     }
 
-    NSString *const query = [[NSString alloc] initWithData:JSONData encoding:NSUTF8StringEncoding];
-    NSString *const encodedString = (NSString *)CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(
-        kCFAllocatorDefault,
-        (CFStringRef)query,
-        NULL,
-        CFSTR(":/?#[]@!$&'()*+,;="),
-        kCFStringEncodingUTF8));
+    // The query parameter character set is everything allowed in the entire query term minus reserved characters.
+    NSMutableCharacterSet *const queryParameterCharacterSet = [[NSCharacterSet URLQueryAllowedCharacterSet] mutableCopy];
+    [queryParameterCharacterSet removeCharactersInString:@":/?#[]@!$&'()*+,;="];
+
+    NSString *const queryDataParameter = [[NSString alloc] initWithData:JSONData encoding:NSUTF8StringEncoding];
+    NSString *const encodedString = [queryDataParameter stringByAddingPercentEncodingWithAllowedCharacters:queryParameterCharacterSet];
     NSString *const URLString = [NSString stringWithFormat:@"%@://payment/create?data=%@", [[self class] _URLScheme], encodedString];
 
     return [NSURL URLWithString:URLString];


### PR DESCRIPTION
The new API for adding percent escapes to URL components is:

```c
-[NSString stringByAddingPercentEncodingWithAllowedCharacters:]
```
