### PR TITLE
Adding AUD because Square Register works in Australia

### DIFF
--- a/SquareRegisterSDK/SCCMoney.m
+++ b/SquareRegisterSDK/SCCMoney.m
@@ -37,7 +37,7 @@ NSString *__nonnull const SCCMoneyRequestDictionaryCurrencyCodeKey = @"currency_
     static NSSet *setOfSupportedISO4217CurrencyCodes = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        setOfSupportedISO4217CurrencyCodes = [NSSet setWithObjects:@"USD", @"CAD", @"JPY", nil];
+        setOfSupportedISO4217CurrencyCodes = [NSSet setWithObjects:@"USD", @"CAD", @"JPY", @"AUD", nil];
     });
     return setOfSupportedISO4217CurrencyCodes;
 }


### PR DESCRIPTION
Square Register works in Australia, see https://squareup.com/help/au/article/4956-international-availability which indicates that "Card payment acceptance with the Square Register app is currently available in the US, Canada, Japan and Australia." Adding AUD to the list of supported currencies. Fixes #4.